### PR TITLE
Ensure swipe module is loaded before runSwipe is invoked

### DIFF
--- a/MudBlazorWasmTeleport/Shared/Swipe.razor
+++ b/MudBlazorWasmTeleport/Shared/Swipe.razor
@@ -1,44 +1,23 @@
-﻿@inject IJSRuntime JSRuntime
-@*
-    -Reference: swipe.js
-    -Location: wwwroot/js/swipe.js
-*@
+@inject IJSRuntime JSRuntime
+@implements IAsyncDisposable
+
 @code {
-    /**/
-    class SwipeSwipe : MudBlazorWasmTeleport.Interfaces.ISwipe
-    {
-        public enum jsSwipeFunctions
-        {
-            runSwipe
-            //stopSwipe,
-        }
-        // To detect redundant calls
-        private bool _disposedValue;
-        private string _jsFunction="";
-        public string JsFunction { get => _jsFunction; set => _jsFunction=value; }
+    private IJSObjectReference? _swipeModule;
 
-        public void RunSwipe(string jsFunc)
-        {
-            _jsFunction = jsFunc;
-            //return JsFunction;
-        }
-
-
-    }
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if(firstRender == true)
+        if (firstRender)
         {
-            SwipeSwipe s = new SwipeSwipe();
-
-            //s.RunSwipe(nameof(Swipe.SwipeSwipe.jsSwipeFunctions.runSwipe));
-            foreach (string item in Enum.GetNames(typeof(Swipe.SwipeSwipe.jsSwipeFunctions)))
-            {
-                s.RunSwipe(item);
-                await JSRuntime.InvokeVoidAsync(s.JsFunction);
-            }
-            //s.RunSwipe("runSwipe");
-            //await JSRuntime.InvokeVoidAsync(s.JsFunction);
+            _swipeModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./js/swipe.js");
+            await _swipeModule.InvokeVoidAsync("runSwipe");
         }
-    } 
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_swipeModule is not null)
+        {
+            await _swipeModule.DisposeAsync();
+        }
+    }
 }

--- a/MudBlazorWasmTeleport/wwwroot/index.html
+++ b/MudBlazorWasmTeleport/wwwroot/index.html
@@ -54,7 +54,6 @@
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
     <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
     <script src="js/AnchorNavigation.js"></script>
-    <script src="js/swipe.js"></script>
 </body>
 
 </html>

--- a/MudBlazorWasmTeleport/wwwroot/js/swipe.js
+++ b/MudBlazorWasmTeleport/wwwroot/js/swipe.js
@@ -1,4 +1,4 @@
-﻿function runSwipe() {
+export function runSwipe() {
     /*
     var swiper = new Swiper(".mySwiper", {
         effect: "coverflow",
@@ -18,13 +18,13 @@
             stretch: 0,
             depth: 0,
             modifier: 1,
-            slideShadows: true,           
+            slideShadows: true,
         },
         pagination: {
             el: ".swiper-pagination",
         },
     });
-    
+
     var swiper = new Swiper(".js-testimonials-slider", {
         //freeMode: true,
         grabCursor: true,
@@ -75,7 +75,7 @@
             768: {
                 slidesPerView: 2,
                 spaceBetween: 44
-            }, 
+            },
             1024: {
                 slidesPerView: 2,
                 spaceBetween: 44


### PR DESCRIPTION
## Summary
- load the swipe JavaScript file as a module during the Swipe component's first render and dispose the reference when finished
- export the `runSwipe` initializer from `swipe.js` so it can be imported reliably and remove the redundant script tag from `index.html`

## Testing
- dotnet build MudBlazorWasmTeleport.sln *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6b6902288331b18a262a68207cf3